### PR TITLE
 JDP201003-22 - Commit XIII

### DIFF
--- a/src/main/java/com/kodilla/ecommerce/controller/GroupController.java
+++ b/src/main/java/com/kodilla/ecommerce/controller/GroupController.java
@@ -27,6 +27,7 @@ public class GroupController {
 
     @PostMapping
     public void createGroup(@RequestBody GroupDto groupDto) {
+        groupService.saveGroup(groupMapper.mapToGroup(groupDto));
     }
 
     @PutMapping


### PR DESCRIPTION
W metodzie crateGroup przepadło:

groupService.saveGroup(groupMapper.mapToGroup(groupDto));